### PR TITLE
fix: suppress body hydration extension attrs

### DIFF
--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -38,7 +38,7 @@ const RootLayout = async ({ children }: RootLayoutProperties) => {
       lang="en"
       suppressHydrationWarning
     >
-      <body className="overflow-hidden">
+      <body className="overflow-hidden" suppressHydrationWarning>
         <QueryProvider>
           <AnalyticsProvider bootstrapFeatureFlags nonce={nonce} trackPageViews>
             <DesignSystemProvider


### PR DESCRIPTION
## Summary
- Add `suppressHydrationWarning` to the root `<body>` element so browser-extension-injected attributes such as Grammarly markers do not surface as React hydration mismatch errors.

## Testing
- `pnpm --filter app typecheck`
- `pnpm typecheck` via commit hook
- `git diff --check`
- `curl -I http://localhost:3000/sign-in` returned 200 locally