### PR TITLE
ci: add gitleaks secret scan

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,41 @@
+name: gitleaks
+
+# Defense-in-depth secret scan for the public Community Edition repo.
+# Independent of the upstream sync gate, so secrets are caught regardless of
+# whether they arrive via the automated sync, a manual commit, or a PR.
+#
+# Default gitleaks ruleset only (provider credentials, tokens). Org-specific
+# proprietary-identifier rules deliberately live ONLY in the private sync gate
+# — embedding them in a config committed to this public repo would itself
+# disclose the identifiers.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan working tree for secrets
+        run: gitleaks dir . --no-banner --redact --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,24 @@
+# gitleaks config for the Community Edition repo's secret scan (.github/workflows/gitleaks.yml).
+#
+# Default ruleset PLUS allowlists for known-benign test fixtures and
+# documentation placeholders. This file is PUBLIC, so it intentionally contains
+# NO proprietary identifiers — org-specific identifier rules are enforced
+# upstream in the private sync gate, before anything reaches this repo.
+
+title = "ClosedLoop CE secret scan"
+
+[extend]
+useDefault = true
+# The product documents its own REST API with curl examples (in docs and in the
+# API-keys settings UI), so an Authorization-header rule perpetually fires on
+# placeholders. Real provider credentials are still covered by the other rules.
+disabledRules = ["curl-auth-header"]
+
+[allowlist]
+description = "Test fixtures and documentation placeholders — no live secrets"
+paths = [
+  '''(^|/)__tests__/''',
+  '''\.test\.(ts|tsx|js|jsx|mjs|cts|mts)$''',
+  '''\.spec\.(ts|tsx|js|jsx|mjs|cts|mts)$''',
+  '''(^|/)docs/github-app-setup\.md$''',  # example RSA key in setup instructions
+]


### PR DESCRIPTION
## What

Adds a **gitleaks** secret scan to the CE repo's CI, on PRs and pushes to `main`. Defense-in-depth, independent of the upstream private→public sync pipeline: secrets are caught regardless of whether they arrive via the automated sync, a manual commit, or a contributor PR.

## How

- Pins **gitleaks 8.30.1** (direct install — avoids the `gitleaks-action@v2` org-license requirement) and runs the **default ruleset** (provider API keys, tokens, private keys, …).
- A repo-root `.gitleaks.toml` allowlists known-benign findings so the gate is green on current `main` while staying meaningful:
  - test fixtures (`__tests__/`, `*.test.*`, `*.spec.*`) — these hold synthetic keys like `sk_live_testkey1234`
  - the example RSA key in `docs/github-app-setup.md`
  - disables `curl-auth-header` (the product is documented with `curl ... -H "Authorization: Bearer ..."` examples)

## Why no org-specific rules here

This config is **public**. Org proprietary-identifier rules (AWS account IDs, internal hostnames, internal repo names) would themselves disclose those identifiers if committed here, so they live **only in the private sync gate**, which runs before anything reaches this repo.

## Validation

- `gitleaks dir .` on current `main`: **clean** (the 12 raw default-rule hits are all triaged false positives — test fixtures + doc placeholders, no live credentials).
- Negative control: a real-shaped `ghp_…` token in a source file is **caught** (exit 1); the same token under `__tests__/` is correctly **allowlisted** (exit 0).

> Companion to the private sync-tooling fix (closedloop-ai/scratch) that root-caused and fixed the proprietary-path leak + lockfile mismatch from the last sync attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)