### PR TITLE
docs(ci): clarify what the desktop-v* tags mean in the release workflow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -12,12 +12,13 @@
 # Cut a release by dispatching this workflow. It reads the version from
 # apps/desktop/package.json.
 #
-# Dispatch-only by design — please don't add a tag trigger. The `desktop-v*`
-# tags in this repository mark the official signed builds that ClosedLoop
-# distributes. Those are produced by a separate release pipeline and attached to
-# a Release here so they can be downloaded without a GitHub account; they are
-# not built from this repository's tree at that tag. Building on a tag push
-# would therefore produce a different artifact than the tag claims.
+# Dispatch-only by design; do not add a tag trigger. The `desktop-v*` tags in
+# this repository mark the official signed builds ClosedLoop distributes: those
+# are built and signed by ClosedLoop's release pipeline and attached to a Release
+# here so they can be downloaded without a GitHub account. Such a tag names the
+# version of that build, not a commit in this repository's tree, so a tag-push
+# build would publish a different artifact under a tag that already means
+# something else.
 name: Release Desktop
 
 on:


### PR DESCRIPTION
## Summary

- The header comment on `desktop-release.yml` explained the `desktop-v*` tags defensively ("please don't add a tag trigger… they are not built from this repository's tree"). Reworded to state what the tag *does* mean: it names the version of a ClosedLoop-built signed build, not a commit in this tree — which is also why a tag-push build would publish the wrong artifact under it.
- Matches the tone of the release notes published on those releases (updated in `closedloop-ai/symphony-alpha#3561`).

## Feature Flags

[flag:N/A] Comment-only change to a CI workflow; no user-facing functionality.

## Test plan

- Comment-only. The workflow remains `workflow_dispatch`-only and is otherwise byte-identical; nothing to run.