### PR TITLE
fix: clamp oversized unknown payloads in historical parse worker responses

### DIFF
--- a/apps/desktop/src/main/collectors/engine/historical-parse-worker-protocol.ts
+++ b/apps/desktop/src/main/collectors/engine/historical-parse-worker-protocol.ts
@@ -1,7 +1,11 @@
 import { truncateUtf8 } from "@closedloop-ai/loops-api/observability";
 import { z } from "zod";
 import { safeStorageTokenCountSchema } from "../../token-counts.js";
-import { HarnessValues, type NormalizedSession } from "../types.js";
+import {
+  HarnessValues,
+  type NormalizedSession,
+  type NormalizedToolUse,
+} from "../types.js";
 
 export const HistoricalParseWorkerLimits = {
   maxWorkerSessionsPerSource: 50_000,
@@ -500,7 +504,12 @@ export function createHistoricalParseWorkerFailedResponse(
 export function clampSessionsForWorkerResponse(
   sessions: NormalizedSession[]
 ): NormalizedSession[] {
-  const limited = sessions.slice(0, MAX_WORKER_SESSIONS_PER_SOURCE);
+  // Bound unknown payload content before trimming array lengths — the response
+  // schema enforces both, and `sliceSessionArrays` alone leaves an oversized
+  // tool input in place (see clampSessionUnknownValues).
+  const limited = sessions
+    .slice(0, MAX_WORKER_SESSIONS_PER_SOURCE)
+    .map((session) => clampSessionUnknownValues(session));
   let limit: number = MAX_SESSION_ARRAY_ITEMS;
   let working = limited.map((session) => sliceSessionArrays(session, limit));
   // Halve the per-array limit until the response-wide item + text budgets fit.
@@ -559,6 +568,122 @@ function sliceSessionArrays(
     }));
   }
   return sliced;
+}
+
+/** Replaces payloads the bounded-unknown validator would reject outright. */
+const TRUNCATED_UNKNOWN_VALUE = "[truncated]";
+
+/**
+ * Bound every schema-`unknown` payload (tool-use input/output, subagent
+ * metadata, teams/compactions/usageExtras entries) to the limits
+ * `isBoundedUnknownValue` enforces. `sliceSessionArrays` only trims array
+ * lengths, so without this pass a single oversized tool input (e.g. a >2MB
+ * Write payload in a transcript) fails response validation and the whole
+ * parse job degrades to a Failed envelope — the source is dropped and
+ * re-parsed on every collector cycle instead of ingesting with truncated
+ * detail.
+ */
+function clampSessionUnknownValues(
+  session: NormalizedSession
+): NormalizedSession {
+  const clamped: NormalizedSession = {
+    ...session,
+    teams: session.teams.map((item) => clampUnknownValue(item, 0)),
+    toolUses: session.toolUses.map((toolUse) =>
+      clampToolUseUnknownValues(toolUse)
+    ),
+    compactions: session.compactions.map((item) => clampUnknownValue(item, 0)),
+    usageExtras: {
+      ...session.usageExtras,
+      service_tiers: session.usageExtras.service_tiers.map((item) =>
+        clampUnknownValue(item, 0)
+      ),
+      speeds: session.usageExtras.speeds.map((item) =>
+        clampUnknownValue(item, 0)
+      ),
+      inference_geos: session.usageExtras.inference_geos.map((item) =>
+        clampUnknownValue(item, 0)
+      ),
+    },
+  };
+  if (session.subagents) {
+    clamped.subagents = session.subagents.map((subagent) => ({
+      ...subagent,
+      toolUses: subagent.toolUses?.map((toolUse) =>
+        clampToolUseUnknownValues(toolUse)
+      ),
+      metadata: subagent.metadata
+        ? Object.fromEntries(
+            Object.entries(subagent.metadata).map(([key, item]) => [
+              key,
+              clampUnknownValue(item, 0),
+            ])
+          )
+        : undefined,
+    }));
+  }
+  return clamped;
+}
+
+function clampToolUseUnknownValues(
+  toolUse: NormalizedToolUse
+): NormalizedToolUse {
+  const input =
+    toolUse.input === undefined
+      ? undefined
+      : clampUnknownValue(toolUse.input, 0);
+  const output =
+    toolUse.output === undefined
+      ? undefined
+      : clampUnknownValue(toolUse.output, 0);
+  if (input === toolUse.input && output === toolUse.output) {
+    return toolUse;
+  }
+  return { ...toolUse, input, output };
+}
+
+/**
+ * Degrade an out-of-bounds unknown value to the nearest in-bounds shape:
+ * oversized strings truncate, oversized arrays/objects drop trailing entries,
+ * non-finite numbers become null, and containers at the depth cap (whose
+ * children the validator rejects wholesale) collapse to a marker string.
+ * Already-bounded values return by reference.
+ */
+function clampUnknownValue(value: unknown, depth: number): unknown {
+  if (isBoundedUnknownValue(value, depth)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    // Only a non-finite number fails the bounded check above.
+    return null;
+  }
+  if (typeof value === "string") {
+    return truncateUtf8(value, MAX_LONG_TEXT_LENGTH);
+  }
+  if (Array.isArray(value)) {
+    if (depth >= MAX_UNKNOWN_DEPTH) {
+      return TRUNCATED_UNKNOWN_VALUE;
+    }
+    return value
+      .slice(0, MAX_UNKNOWN_ARRAY_ITEMS)
+      .map((item) => clampUnknownValue(item, depth + 1));
+  }
+  if (isPlainRecord(value)) {
+    if (depth >= MAX_UNKNOWN_DEPTH) {
+      return TRUNCATED_UNKNOWN_VALUE;
+    }
+    return Object.fromEntries(
+      Object.entries(value)
+        .slice(0, MAX_UNKNOWN_OBJECT_KEYS)
+        .map(([key, item]) => [
+          key.slice(0, MAX_SHORT_TEXT_LENGTH),
+          clampUnknownValue(item, depth + 1),
+        ])
+    );
+  }
+  // null/boolean/finite numbers are always bounded; anything else (bigint,
+  // function, class instance) has no bounded representation.
+  return TRUNCATED_UNKNOWN_VALUE;
 }
 
 /**

--- a/apps/desktop/test/historical-parse-worker-protocol.test.ts
+++ b/apps/desktop/test/historical-parse-worker-protocol.test.ts
@@ -861,6 +861,109 @@ test("clampSessionsForWorkerResponse trims an oversized session to a valid respo
   assert.ok(clamped[0] !== undefined && clamped[0].messages.length < 5000);
 });
 
+test("clampSessionsForWorkerResponse bounds oversized unknown payloads to a valid response", () => {
+  // Raw, the session is rejected by the response schema — the failure operators
+  // saw in the wild ("sessions.0.toolUses.N.input:custom:Invalid input").
+  assert.equal(
+    historicalParseWorkerResponseSchema.safeParse({
+      type: HistoricalParseWorkerResponseType.Parsed,
+      requestId: "historical-parse-1",
+      sessions: [makeUnboundedPayloadSession("unbounded-payloads")],
+    }).success,
+    false
+  );
+
+  // Clamped, the same session yields a response that validates.
+  const clamped = clampSessionsForWorkerResponse([
+    makeUnboundedPayloadSession("unbounded-payloads"),
+  ]);
+  const result = historicalParseWorkerResponseSchema.safeParse({
+    type: HistoricalParseWorkerResponseType.Parsed,
+    requestId: "historical-parse-1",
+    sessions: clamped,
+  });
+
+  assert.equal(result.success, true);
+  // Every tool use survives with degraded payloads instead of failing the job.
+  const [session] = clamped;
+  assert.equal(session?.toolUses.length, 3);
+  const clampedContent = (session?.toolUses[0]?.input as { content: string })
+    .content;
+  assert.ok(
+    Buffer.byteLength(clampedContent) <=
+      HistoricalParseWorkerLimits.maxLongTextLength
+  );
+  assert.ok(clampedContent.startsWith("xxx"));
+  assert.ok(
+    Array.isArray(session?.toolUses[1]?.output) &&
+      session.toolUses[1].output.length <=
+        HistoricalParseWorkerLimits.maxUnknownArrayItems
+  );
+  // In-bounds fields on the same tool uses pass through untouched.
+  assert.equal(session?.toolUses[1]?.name, "Bash");
+});
+
+test("createHistoricalParseWorkerParsedResponse keeps sessions with oversized unknown payloads", () => {
+  const response = createHistoricalParseWorkerParsedResponse(
+    "historical-parse-1",
+    [makeUnboundedPayloadSession("unbounded-payloads")]
+  );
+
+  assert.equal(response.type, HistoricalParseWorkerResponseType.Parsed);
+});
+
+function makeUnboundedPayloadSession(sessionId: string): NormalizedSession {
+  const session = makeSession(sessionId);
+  const overLongText = "x".repeat(
+    HistoricalParseWorkerLimits.maxLongTextLength + 1
+  );
+  let overDeepValue: unknown = "leaf";
+  for (let i = 0; i <= HistoricalParseWorkerLimits.maxUnknownDepth + 1; i++) {
+    overDeepValue = { nested: overDeepValue };
+  }
+  session.toolUses = [
+    {
+      name: "Write",
+      timestamp: "2026-06-07T12:00:00.000Z",
+      input: { content: overLongText },
+    },
+    {
+      name: "Bash",
+      timestamp: "2026-06-07T12:00:01.000Z",
+      input: overDeepValue,
+      output: Array.from(
+        { length: HistoricalParseWorkerLimits.maxUnknownArrayItems + 1 },
+        (_, index) => index
+      ),
+    },
+    {
+      name: "Read",
+      timestamp: "2026-06-07T12:00:02.000Z",
+      input: Object.fromEntries(
+        Array.from(
+          { length: HistoricalParseWorkerLimits.maxUnknownObjectKeys + 1 },
+          (_, index) => [`key-${index}`, index]
+        )
+      ),
+    },
+  ];
+  session.subagents = [
+    {
+      id: "agent-1",
+      name: "Researcher",
+      toolUses: [
+        {
+          name: "Read",
+          timestamp: "2026-06-07T12:00:30.000Z",
+          input: { content: overLongText },
+        },
+      ],
+      metadata: { elapsedMs: Number.POSITIVE_INFINITY },
+    },
+  ];
+  return session;
+}
+
 function makeAggregateHeavySession(sessionId: string): NormalizedSession {
   const session = makeSession(sessionId);
   session.messages = Array.from({ length: 5000 }, () => ({


### PR DESCRIPTION
## Summary

- Fixes #60: one oversized tool-use payload made the historical parse worker reject its whole parse job, so the affected sources re-parsed and re-failed on every collector cycle and the boot import never settled.
- `clampSessionsForWorkerResponse` now bounds every schema-`unknown` payload (tool-use `input`/`output`, subagent `metadata`, `teams`, `compactions`, `usageExtras` entries) to the same limits `isBoundedUnknownValue` enforces, before the existing array-length slicing. Oversized strings truncate (`truncateUtf8`), oversized arrays/objects drop trailing entries, non-finite numbers become `null`, and containers at the depth cap collapse to a `"[truncated]"` marker. Already-bounded values return by reference, so the common case allocates nothing new.
- This makes the existing contract comment on `HistoricalParseWorkerLimits` ("the producer clamps to these limits before sending, so the response always validates") hold for payload content, not just array lengths.

## Root cause

The worker validates parsed sessions with `boundedUnknownValueSchema` before they cross the utility-process boundary, but the producer-side clamp (`sliceSessionArrays`) only trims array lengths. A transcript with one tool-use input past any bound (a >2MB string, >1000 array items, >250 object keys, depth >8, or a non-finite number) failed validation, and `createHistoricalParseWorkerParsedResponse` degraded the whole job to a Failed envelope:

```
agent-collectors: historical parse worker sent an invalid response for historical-parse-12369: sessions.0.toolUses.132.input:custom:Invalid input
agent-collectors: boot import watchdog fired; the import did not settle, surfacing the graceful partial-import state so the splash cannot hang (collectors keep running)
```

Observed on a live desktop v0.16.1133 install: 33 rejected parse jobs in two hours, same sessions each cycle, sessions permanently missing from metrics. Easy to hit with Claude Code transcripts — one large `Write` tool input is enough.

## Feature Flags

- [x] No new functionality introduced (bug fix, refactor, tests only)

## Test plan

- New failing-first test: `clampSessionsForWorkerResponse bounds oversized unknown payloads to a valid response` — a session with an over-long string input, an over-deep input, an over-long array output, an over-wide object input, and a subagent with an oversized input and a non-finite metadata value is rejected raw, validates after clamping, and keeps every tool use with degraded payloads.
- New failing-first test: `createHistoricalParseWorkerParsedResponse keeps sessions with oversized unknown payloads` — the response type is `parsed` (was `failed`), which is the user-visible regression.
- `pnpm exec tsx --test test/historical-parse-worker-protocol.test.ts`: 36 pass, 0 fail.
- `pnpm test:node` (full desktop node suite): 4180 pass, 19 fail — every failure also fails on a clean `origin/main` checkout in the same environment (verified by set-diff of failing test names). They are local-environment baseline issues, not from this change: the golden-session corpus (`packages/golden-sessions`) is absent from the public repo, the release-workflow tests expect workflow files not present here, and one spawn-hardening test inherits this machine's global `commit.gpgsign=true` into its temp repo while the hardened child PATH cannot resolve `gpg`.
- `pnpm typecheck` and `biome check` on the changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
