### PR TITLE
feat: add the minimum startup recipes to the justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,6 +3,10 @@ default:
     @just --list
 
 # Start the main app, API, and relay
+# Install all workspace dependencies
+install:
+    pnpm install
+
 dev:
     pnpm --filter @closedloop-ai/loops-api build
     RELAY_API_URL=http://localhost:3020 pnpm turbo dev --filter=app --filter=api --filter=mcp --filter=relay
@@ -10,6 +14,10 @@ dev:
 # Start all apps (may fail if mintlify/stripe not installed)
 dev-all:
     pnpm dev
+
+# Start the design-system prototype sandbox on http://localhost:3030
+prototypes:
+    pnpm --filter prototypes dev
 
 # Database commands
 migrate:
@@ -29,6 +37,20 @@ db-migrate name="":
 
 db-migrate-reset:
     cd packages/database && pnpm prisma migrate reset
+
+# Desktop app (Electron)
+
+# Run the desktop app in development against the hosted *.closedloop.ai stack
+desktop-dev:
+    cd apps/desktop && pnpm run dev
+
+# Run desktop against a local stack on localhost, gateway auth off
+desktop-local:
+    cd apps/desktop && \
+    CL_WEB_APP_ORIGIN=http://localhost:3000 \
+    CL_AUTH_API_ORIGIN=http://localhost:3002 \
+    CL_RELAY_ORIGIN=http://localhost:3020 \
+    CL_LOCAL_GATEWAY_NO_AUTH=1 pnpm run dev
 
 # Build and check
 build:


### PR DESCRIPTION
`just desktop-dev` is the primary desktop entry point in the internal monorepo and has been since 2026-06-29, but the `justfile` is a root file the upstream sync never copies — so this repo's copy drifted and never gained it, nor `install`, nor a way into the prototype sandbox that #62 just published.

## What this adds

| Recipe | |
|---|---|
| `install` | `pnpm install` |
| `prototypes` | the design-system sandbox on :3030, published in #62 |
| `desktop-dev` | desktop against the hosted `*.closedloop.ai` stack |
| `desktop-local` | desktop against a local stack, gateway auth off |

22 lines, no changes to existing recipes.

## Deliberately not ported

Upstream has 40 recipes; this takes 4. The rest are either unusable here or redundant:

- **`setup`** — calls `local.env.example` and `scripts/setup-local-env.sh`, neither of which exists in this repo. It would fail on first run, which is the worst place to ship a broken recipe. First-run setup stays as documented in `CONTRIBUTING.md`.
- **The other 12 `desktop-*` recipes** — one-line wrappers around the `pnpm desktop:*` scripts the root `package.json` already exposes.
- **The 5 `profile-*` recipes** — internal QA sandbox tooling.
- **`desktop-golden`** — needs `packages/golden-sessions`, which is not published here.

## Test plan

`just --list` parses and resolves `desktop-dev`, `desktop-local`, `install` and `prototypes`. No existing recipe is modified, so nothing else can regress.